### PR TITLE
Added acronym to 5.1 subdomain title. Fixes #76.

### DIFF
--- a/source/all_collections/_subdomains/5_1_standard_operating_procedures_and_documentation.md
+++ b/source/all_collections/_subdomains/5_1_standard_operating_procedures_and_documentation.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "[5.1] Standard Operating Procedures & documentation"
+title: "[5.1] Standard Operating Procedures (SOPs) & documentation"
 parent: "5OS"
 indicators:
  - indicator: '[5.1.1] Internal node operation SOPs defined and documentation available'


### PR DESCRIPTION
Added SOP acronym to 5.1 subdomain title to clarify its usage in the indicator and level texts. Fixes issue #76.