### PR TITLE
American to British English (and other consistency fixes). Fixes #98.

### DIFF
--- a/all_collections/_domains/1_governance_strategy_sustainability.md
+++ b/all_collections/_domains/1_governance_strategy_sustainability.md
@@ -6,4 +6,4 @@ identifier: "1GSS"
 
 ## [1] Governance, Strategy and Sustainability
 
-This domain contains all indicators related to the establishment, management and long-term operation of the FEGA node. Indicators are deemed to provide a guideline to ensure strategic alignment with the FEGA ecosystem while allowing each node to respond to the requirement of their decision/policy/funding making bodies
+This domain contains all indicators related to the establishment, management, and long-term operation of the FEGA node. Indicators are deemed to provide a guideline to ensure strategic alignment with the FEGA ecosystem while allowing each node to respond to requirements of their decision-making, policy-making, and funding bodies.

--- a/all_collections/_domains/2_legal.md
+++ b/all_collections/_domains/2_legal.md
@@ -6,4 +6,4 @@ identifier: "2L"
 
 ## [2] Legal
 
-This domain contains all relevant aspects regarding the legal framework where FEGA nodes operate
+This domain contains all relevant aspects regarding the legal framework where FEGA nodes operate.

--- a/all_collections/_domains/3_data_metadata_management.md
+++ b/all_collections/_domains/3_data_metadata_management.md
@@ -6,4 +6,4 @@ identifier: "3DMM"
 
 ## [3] Data and Metadata Management
 
-This domain contains all indicators related to the secure management of sensitive data and associated metadata following existing norms and regulations at institutional, regional, national and, if appropriate, European levels.
+This domain contains all indicators related to the secure management of sensitive data and associated metadata following existing standards and regulations at institutional, regional, national, and, if appropriate, European levels.

--- a/all_collections/_domains/4_technical_infrastructure.md
+++ b/all_collections/_domains/4_technical_infrastructure.md
@@ -6,4 +6,4 @@ identifier: "4TI"
 
 ## [4] Technical Infrastructure
 
-This domain contains all the indicators about the technical infrastructure needed for the FEGA nodes to be part of the network. It includes software stack, technical benchmarking, storage system, and network interfaces.
+This domain contains all the indicators about the technical infrastructure needed for the FEGA nodes to be part of the network. It includes software stack, technical benchmarking, storage system and network interfaces.

--- a/all_collections/_domains/4_technical_infrastructure.md
+++ b/all_collections/_domains/4_technical_infrastructure.md
@@ -6,4 +6,4 @@ identifier: "4TI"
 
 ## [4] Technical Infrastructure
 
-This domain contains all the indicators about the technical infrastructure needed for the FEGA nodes to be part of the network. It includes software stack, technical benchmarking, storage system and network interfaces.
+This domain contains all the indicators about the technical infrastructure needed for the FEGA nodes to be part of the network. It includes software stack, technical benchmarking, storage system, and network interfaces.

--- a/all_collections/_domains/6_communications_community_building_and_engagement.md
+++ b/all_collections/_domains/6_communications_community_building_and_engagement.md
@@ -6,4 +6,4 @@ identifier: "6CCBE"
 
 ## [6] Communications, Community Building, and Engagement
 
-This domain covers all aspects related to the communication and outreach activities of the FEGA node, including specific actions with relevant research communities. As part of the transversal activities, this domain also includes aspects on Capacity building in connection with the FEGA ecosystem.
+This domain covers all aspects related to the communication and outreach activities of the FEGA node, including specific actions with relevant research communities. As part of the transversal activities, this domain also includes aspects of capacity building in connection with the FEGA ecosystem.

--- a/all_collections/_subdomains/1_1_governance_and_structure_of_the_federated_ega_node.md
+++ b/all_collections/_subdomains/1_1_governance_and_structure_of_the_federated_ega_node.md
@@ -14,5 +14,5 @@ indicators:
     - level: 4
       desc: 'Governance body is fully operating with key personnel and is monitored based on work plan.'
     - level: 5
-      desc: 'Governance body is institutionalized, protected from organizational changes, open to novel developments and supportive of international cooperation.'
+      desc: 'Governance body is institutionalised, protected from organisational changes, open to novel developments and supportive of international cooperation.'
 ---

--- a/all_collections/_subdomains/1_1_governance_and_structure_of_the_federated_ega_node.md
+++ b/all_collections/_subdomains/1_1_governance_and_structure_of_the_federated_ega_node.md
@@ -10,7 +10,7 @@ indicators:
     - level: 2
       desc: 'The team is assembled and proposed roles identified.'
     - level: 3  
-      desc: 'Overall governance body and node structure is defined, with stakeholder consultation, and formally approved including key roles, e.g. DPO.'
+      desc: 'Overall governance body and node structure is defined, with stakeholder consultation, and formally approved including key roles.'
     - level: 4
       desc: 'Governance body is fully operating with key personnel and is monitored based on work plan.'
     - level: 5

--- a/all_collections/_subdomains/2_2_federated_ega_node_collaboration_agreement.md
+++ b/all_collections/_subdomains/2_2_federated_ega_node_collaboration_agreement.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: "[2.2] FEGA node Collaboration agreement"
+title: "[2.2] FEGA Collaboration Agreement"
 parent: "2L"
 indicators:
- - indicator: '[2.2.1] FEGA node Collaboration agreement established'
+ - indicator: '[2.2.1] FEGA Collaboration Agreement established'
    connected:
     - ind: '1.1.1'
     - ind: '1.2.1'
@@ -11,11 +11,11 @@ indicators:
     - level: 1
       desc: 'Informal interest expressed.'
     - level: 2
-      desc: 'Express the intention of becoming a new FEGA node by requesting to start the Collaboration agreement signing process.'
+      desc: 'Express the intention of becoming a new FEGA node by requesting to start the FEGA Collaboration Agreement signing process.'
     - level: 3  
-      desc: 'FEGA node is acknowledged including the negotiation to sign up the Collaboration agreement.'
+      desc: 'FEGA node is acknowledged including the negotiation to sign the FEGA Collaboration Agreement.'
     - level: 4
-      desc: 'FEGA node collaboration agreement is signed and the Node become a recognized part of the FEGA.'
+      desc: 'FEGA Collaboration Agreement is signed and the Node become a recognized part of the FEGA.'
     - level: 5
-      desc: 'Periodic review of the Collaboration agreement being amended whenever necessary.'
+      desc: 'Periodic review of the FEGA Collaboration Agreement being amended whenever necessary.'
 ---

--- a/all_collections/_subdomains/2_2_federated_ega_node_collaboration_agreement.md
+++ b/all_collections/_subdomains/2_2_federated_ega_node_collaboration_agreement.md
@@ -15,7 +15,7 @@ indicators:
     - level: 3  
       desc: 'FEGA node is acknowledged including the negotiation to sign the FEGA Collaboration Agreement.'
     - level: 4
-      desc: 'FEGA Collaboration Agreement is signed and the Node become a recognized part of the FEGA.'
+      desc: 'FEGA Collaboration Agreement is signed and the Node become a recognised part of the FEGA.'
     - level: 5
       desc: 'Periodic review of the FEGA Collaboration Agreement being amended whenever necessary.'
 ---

--- a/all_collections/_subdomains/2_3_legal_agreement_between_the_federated_ega_node_and_its_users.md
+++ b/all_collections/_subdomains/2_3_legal_agreement_between_the_federated_ega_node_and_its_users.md
@@ -12,7 +12,7 @@ indicators:
     - level: 2
       desc: 'Initial DPA template is drafted, taking into account local regulations, for data submission cases that require a DPA.'
     - level: 3  
-      desc: 'DPA template incorporates elements from the FEGA Ecosystem to ensure consistency.'
+      desc: 'DPA template incorporates elements from the FEGA ecosystem to ensure consistency.'
     - level: 4
       desc: 'DPA template is approved by the institution hosting the FEGA node and can be distributed to submitters.'
     - level: 5

--- a/all_collections/_subdomains/3_1_secure_management_of_data_at_physical_and_logical_levels.md
+++ b/all_collections/_subdomains/3_1_secure_management_of_data_at_physical_and_logical_levels.md
@@ -36,7 +36,7 @@ indicators:
     - level: 1
       desc: 'No risk register.'
     - level: 2
-      desc: 'Risk register planning in preparation, relevant people identified as responsible for RR at node.'
+      desc: 'Risk register planning in preparation, relevant people identified as responsible for Risk register at node.'
     - level: 3  
       desc: 'Risks identified, documented and assigned to appropriate personnel for review.'
     - level: 4

--- a/all_collections/_subdomains/3_1_secure_management_of_data_at_physical_and_logical_levels.md
+++ b/all_collections/_subdomains/3_1_secure_management_of_data_at_physical_and_logical_levels.md
@@ -25,7 +25,7 @@ indicators:
     - level: 3  
       desc: 'Partial automation of the data flow approval process.'
     - level: 4
-      desc: 'Datasets are tagged with appropriate usage conditions using, for instance, GA4GH DUO. This would partially guide DAC approvals, accelerating the data access process.'
+      desc: 'Datasets are tagged with appropriate usage conditions. This would partially guide DAC approvals, accelerating the data access process.'
     - level: 5
       desc: 'Application for access is semi-automated and follows international standards. Process is periodically reviewed to ensure time efficient access.'
 

--- a/all_collections/_subdomains/3_2_incoming_and_outgoing_data_and_metadata_flow.md
+++ b/all_collections/_subdomains/3_2_incoming_and_outgoing_data_and_metadata_flow.md
@@ -27,7 +27,7 @@ indicators:
     - level: 2
       desc: 'First methods are drafted and proposed for the data distribution out of the FEGA node.'
     - level: 3  
-      desc: 'Ad-hoc distribution of data out of the FEGA Node to approved users using manual/non-scalable mechanisms.'
+      desc: 'Ad hoc distribution of data out of the FEGA Node to approved users using manual/non-scalable mechanisms.'
     - level: 4
       desc: 'Data can flow out of node in a semi-automated or self-service way for approved users using secure protocols. Majority of data distribution scenarios agreed by the FEGA ecosystem are supported by the node.'
     - level: 5

--- a/all_collections/_subdomains/3_3_data_reception_and_standards_based_interoperability.md
+++ b/all_collections/_subdomains/3_3_data_reception_and_standards_based_interoperability.md
@@ -46,7 +46,7 @@ indicators:
     - level: 3  
       desc: 'Metadata is ingested with limited formatting and minimum standards. Basic tools used for metadata collection (e.g. spreadsheets) and validation are deployed. Metadata management is partially automated.'
     - level: 4
-      desc: 'Metadata management is automated and becomes more holistic including the harmonized metadata standards, e.g. relevant ontologies. Tooling and support is available for submitters and data requesters,  including curation services, if needed.'
+      desc: 'Metadata management is automated and becomes more holistic including the harmonised metadata standards, e.g. relevant ontologies. Tooling and support is available for submitters and data requesters,  including curation services, if needed.'
     - level: 5
       desc: 'Periodic review of metadata standards and harmonisation efforts to maintain them up-to-date and consider extension and adoption when new uses are identified/mandated.'
 ---

--- a/all_collections/_subdomains/3_3_data_reception_and_standards_based_interoperability.md
+++ b/all_collections/_subdomains/3_3_data_reception_and_standards_based_interoperability.md
@@ -32,7 +32,7 @@ indicators:
     - level: 4
       desc: 'Data standards and file types assessment workflow is fully implemented. Assessment is automated and part of the incoming data process in the FEGA node.'
     - level: 5
-      desc: 'Periodic review of the Data standards and file types assessment criteria and workflow. Criteria and workflows can be refined to maintain general agreement with the FEGA ecosystem work in this topic.'
+      desc: 'Periodic review of the data standards and file types assessment criteria and workflow. Criteria and workflows can be refined to maintain general agreement with the FEGA ecosystem work in this topic.'
 
  - indicator: '[3.3.3] Metadata standards and harmonisation implemented'
    connected:

--- a/all_collections/_subdomains/4_3_storage_system.md
+++ b/all_collections/_subdomains/4_3_storage_system.md
@@ -17,7 +17,7 @@ indicators:
     - level: 4
       desc: 'The FEGA node has a complete and implemented plan to maintain or increase its capacity when required.'
     - level: 5
-      desc: "Periodic revision of the Storage Capacity Planning according to utilization KPI's of the FEGA node updating it whenever necessary."
+      desc: "Periodic revision of the Storage Capacity Planning according to utilisation KPI's of the FEGA node updating it whenever necessary."
 
  - indicator: '[4.3.2] Storage Robustness'
    levels:

--- a/all_collections/_subdomains/4_3_storage_system.md
+++ b/all_collections/_subdomains/4_3_storage_system.md
@@ -17,7 +17,7 @@ indicators:
     - level: 4
       desc: 'The FEGA node has a complete and implemented plan to maintain or increase its capacity when required.'
     - level: 5
-      desc: "Periodic revision of the Storage Capacity Planning according to utilisation KPI's of the FEGA node updating it whenever necessary."
+      desc: 'Periodic revision of the Storage Capacity Planning according to utilisation KPIs of the FEGA node updating it whenever necessary.'
 
  - indicator: '[4.3.2] Storage Robustness'
    levels:
@@ -28,7 +28,7 @@ indicators:
     - level: 3  
       desc: 'Node has a system to prevent data loss.'
     - level: 4
-      desc: 'Node follow the FEGA guidelines for data storage, redundancy and access to avoid data loss.'
+      desc: 'Node follows the FEGA guidelines for data storage, redundancy and access to avoid data loss.'
     - level: 5
       desc: 'Annual auditing and revision of the storage system is established to guarantee the alignment with the FEGA guidelines for data storage.'
 ---

--- a/all_collections/_subdomains/4_4_network_interfaces.md
+++ b/all_collections/_subdomains/4_4_network_interfaces.md
@@ -16,7 +16,7 @@ indicators:
     - level: 4
       desc: 'The FEGA node has a complete and implemented network capacity plan, which can be increased whenever required.'
     - level: 5
-      desc: "Periodic revision of the Network Capacity Planning according to network congestion KPI's of the FEGA node updating it whenever necessary."
+      desc: 'Periodic revision of the Network Capacity Planning according to network congestion KPIs of the FEGA node updating it whenever necessary.'
 
  - indicator: '[4.4.2] Network Reliability / Security'
    connected:
@@ -26,7 +26,7 @@ indicators:
     - level: 1
       desc: 'None.'
     - level: 2
-      desc: 'Incidents are resolved but not classified not managed by the FEGA node. Drafted security network strategies to avoid common vulnerabilities.'
+      desc: 'Incidents are resolved but not classified nor managed by the FEGA node. Drafted security network strategies to avoid common vulnerabilities.'
     - level: 3  
       desc: 'Node has implementation of mitigation strategies for vulnerabilities. An incident reporting system is drafted and partially implemented allowing to gain experience on those incidents.'
     - level: 4

--- a/all_collections/_subdomains/4_5_internal_compute_capacity.md
+++ b/all_collections/_subdomains/4_5_internal_compute_capacity.md
@@ -10,9 +10,9 @@ indicators:
     - level: 2
       desc: 'Internal computing capacity needs are not planned, but sufficient computing resources can be obtained as the node needs.'
     - level: 3  
-      desc: "A plan to obtain and maintain internal computing capacity required for node services is drafted, considering hosting institution policies and node services required in the FEGA ecosystem."
+      desc: 'A plan to obtain and maintain internal computing capacity required for node services is drafted, considering hosting institution policies and node services required in the FEGA ecosystem.
     - level: 4
-      desc: "The FEGA node has a complete and implemented plan to maintain sufficient internal computing capacity for required services and increase capacity when needed."
+      desc: 'The FEGA node has a complete and implemented plan to maintain sufficient internal computing capacity for required services and increase capacity when needed.'
     - level: 5
-      desc: "Periodic revision of the Internal Computing Capacity Planning according to utilization KPI's of the FEGA node updating it whenever necessary."
+      desc: 'Periodic revision of the Internal Computing Capacity Planning according to utilization KPIs of the FEGA node, updating it whenever necessary.'
 ---

--- a/all_collections/_subdomains/4_5_internal_compute_capacity.md
+++ b/all_collections/_subdomains/4_5_internal_compute_capacity.md
@@ -10,9 +10,9 @@ indicators:
     - level: 2
       desc: 'Internal computing capacity needs are not planned, but sufficient computing resources can be obtained as the node needs.'
     - level: 3  
-      desc: 'A plan to obtain and maintain internal computing capacity required for node services is drafted, considering hosting institution policies and node services required in the FEGA ecosystem.
+      desc: 'A plan to obtain and maintain internal computing capacity required for node services is drafted, considering hosting institution policies and node services required in the FEGA ecosystem.'
     - level: 4
       desc: 'The FEGA node has a complete and implemented plan to maintain sufficient internal computing capacity for required services and increase capacity when needed.'
     - level: 5
-      desc: 'Periodic revision of the Internal Computing Capacity Planning according to utilization KPIs of the FEGA node, updating it whenever necessary.'
+      desc: 'Periodic revision of the Internal Computing Capacity Planning according to utilisation KPIs of the FEGA node, updating it whenever necessary.'
 ---

--- a/all_collections/_subdomains/5_1_standard_operating_procedures_and_documentation.md
+++ b/all_collections/_subdomains/5_1_standard_operating_procedures_and_documentation.md
@@ -12,7 +12,7 @@ indicators:
     - level: 3  
       desc: 'Template for SOPs created. SOPs for key operations generated and approved by key personnel and stored in accessible location for all appropriate staff.'
     - level: 4
-      desc: 'SOPs for additional/new and  "ad hoc" processes defined and added to accessible location.'
+      desc: 'SOPs for additional/new and ad hoc processes defined and added to accessible location.'
     - level: 5
       desc: 'SOPs audited internally and reviewed annually.'
 
@@ -25,7 +25,7 @@ indicators:
     - level: 3  
       desc: 'Template for SOPs created. SOPs for key operations generated and approved by key personnel and stored in accessible location for all appropriate staff.'
     - level: 4
-      desc: 'SOPs for additional/new and  "ad hoc" processes defined and added to accessible location.'
+      desc: 'SOPs for additional/new and ad hoc processes defined and added to accessible location.'
     - level: 5
       desc: 'SOPs audited and reviewed annually.'
 

--- a/all_collections/_subdomains/6_1_appropriate_stakeholder_research_community_engagement.md
+++ b/all_collections/_subdomains/6_1_appropriate_stakeholder_research_community_engagement.md
@@ -15,7 +15,7 @@ indicators:
     - level: 3  
       desc: 'The different roles of the FEGA node users are identified and mechanisms to communicate with them are designed.'
     - level: 4
-      desc: 'Well-developed communication materials and channels are provided, emphasizing the commitment of the FEGA node in research data sharing.'
+      desc: 'Well-developed communication materials and channels are provided, emphasising the commitment of the FEGA node in research data sharing.'
     - level: 5
       desc: 'Periodic review of engagement strategy and materials and the coordination with other FEGA nodes and relevant projects to develop a common agenda for awareness raising.'
 ---

--- a/all_collections/_subdomains/6_2_capacity_building_driven_by_the_federated_ega_node.md
+++ b/all_collections/_subdomains/6_2_capacity_building_driven_by_the_federated_ega_node.md
@@ -14,5 +14,5 @@ indicators:
     - level: 4
       desc: 'Adapted training materials by the FEGA node is delivered to local users.'
     - level: 5
-      desc: 'Periodic review of available trainings at the FEGA node and its contributions to the FEGA Ecosystem.'
+      desc: 'Periodic review of available trainings at the FEGA node and its contributions to the FEGA ecosystem.'
 ---

--- a/all_collections/_subdomains/6_3_dedicated_public_communication_strategy.md
+++ b/all_collections/_subdomains/6_3_dedicated_public_communication_strategy.md
@@ -15,7 +15,7 @@ indicators:
     - level: 3  
       desc: 'Leverage the existing generic communication package by the FEGA ecosystem to establish the digital entity of the FEGA node.'
     - level: 4
-      desc: 'Customized communication package to various FEGA node stakeholders: language-specific, audience-specific (end-users, funders).'
+      desc: 'Customised communication package to various FEGA node stakeholders: language-specific, audience-specific (end-users, funders).'
     - level: 5
-      desc: 'Periodic review of communication package updating it whenever necessary to maximize impact. Contribute towards the generic communication package of the FEGA ecosystem.'
+      desc: 'Periodic review of communication package updating it whenever necessary to maximise impact. Contribute towards the generic communication package of the FEGA ecosystem.'
 ---

--- a/all_collections/_subdomains/6_3_dedicated_public_communication_strategy.md
+++ b/all_collections/_subdomains/6_3_dedicated_public_communication_strategy.md
@@ -11,11 +11,11 @@ indicators:
     - level: 1
       desc: 'None.'
     - level: 2
-      desc: 'Initial (and informal) communications for the FEGA node are happening.'
+      desc: 'Initial and informal communications for the FEGA node are happening.'
     - level: 3  
       desc: 'Leverage the existing generic communication package by the FEGA ecosystem to establish the digital entity of the FEGA node.'
     - level: 4
-      desc: 'Customized communication package to various FEGA node stakeholders: language specific, audience specific (end-users, funders).'
+      desc: 'Customized communication package to various FEGA node stakeholders: language-specific, audience-specific (end-users, funders).'
     - level: 5
       desc: 'Periodic review of communication package updating it whenever necessary to maximize impact. Contribute towards the generic communication package of the FEGA ecosystem.'
 ---

--- a/all_collections/_subdomains/6_3_dedicated_public_communication_strategy.md
+++ b/all_collections/_subdomains/6_3_dedicated_public_communication_strategy.md
@@ -15,7 +15,7 @@ indicators:
     - level: 3  
       desc: 'Leverage the existing generic communication package by the FEGA ecosystem to establish the digital entity of the FEGA node.'
     - level: 4
-      desc: 'Customised communication package to various FEGA node stakeholders: language-specific, audience-specific (end-users, funders).'
+      desc: 'Customised communication package to various FEGA node stakeholders: language-specific, audience-specific.'
     - level: 5
       desc: 'Periodic review of communication package updating it whenever necessary to maximise impact. Contribute towards the generic communication package of the FEGA ecosystem.'
 ---


### PR DESCRIPTION
The following changes were made to all domain and subdomain pages in order to make everything more consistent:
- Changed American English spelling to British English spelling
- Made minor grammar and punctuation fixes, e.g. verb tenses, word hyphenation
- Removed capitalisation of words when it did not make sense, e.g. ecosystem
- Changed double quotes to single quotes for levels
- Removed examples in levels
- Changed to "FEGA Collaboration Agreement" to be consistent with the name of this document
- Spelled out acronyms where not defined